### PR TITLE
Fixed possible null exception in ImGuiManager

### DIFF
--- a/Generator/Test/EvergineImGUITest/Managers/ImGuiManager.cs
+++ b/Generator/Test/EvergineImGUITest/Managers/ImGuiManager.cs
@@ -104,7 +104,11 @@ namespace EvergineImGUITest.Managers
         {
             base.OnDeactivated();
 
-            var display = this.renderManager.ActiveCamera3D.Display;
+            var display = this.renderManager.ActiveCamera3D?.Display;
+            if ( display == null ) {
+                return;
+            }
+            
             display.DisplaySizeChanged -= this.Display_DisplaySizeChanged;
             display.DisplayFrameBufferChanged -= this.Display_DisplayFrameBufferChanged;
             this.renderManager.ActiveCamera3D.DrawContext.OnPostRender -= this.DrawContext_OnPostRender;


### PR DESCRIPTION
I ran into this exception after adding ImGUI version `2023.3.1.2` to an Evergine project, it happens when closing the application.

My assumption is that the camera is disposed before the `ImGuiManager`, making the `ActiveCamera3D` property return null.

Please let me know if any changes are required before this can be merged.