### PR TITLE
fix: build wasm with the Emscripten the .NET SDK links with

### DIFF
--- a/.github/workflows/build-native-libs.yml
+++ b/.github/workflows/build-native-libs.yml
@@ -55,11 +55,16 @@ jobs:
       run: |
         sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
+    # Matches the Emscripten the .NET SDK links with, which is what makes the static
+    # archive we ship usable. dotnet/emsdk pins 3.1.56 on release/9.0, release/10.0 and
+    # .NET 11 through preview 5; 3.1.56 expects LLVM 19, while the 3.1.34 previously
+    # used here expects LLVM 17 -- and the published cimgui.a did declare clang 17,
+    # two generations behind the linker. Do not raise this past what the SDK pins.
     - name: Install Emscripten
       if: matrix.arch == 'wasm'
       uses: mymindstorm/setup-emsdk@v14
       with:
-        version: 3.1.34
+        version: 3.1.56
         actions-cache-folder: 'emsdk-cache'
 
     - name: Build

--- a/NativeLibraries/build.py
+++ b/NativeLibraries/build.py
@@ -131,8 +131,20 @@ def build_wasm():
         emsdkPath = input("Please enter the path to your Emscripten SDK: ")
 
     emsdkToolchain = os.path.join(emsdkPath, "upstream", "emscripten", "cmake", "Modules", "Platform", "Emscripten.cmake")
-    emsdkNodePath = os.path.join(emsdkPath, "node")
-    emsdkNodePath = os.path.join(emsdkNodePath, os.listdir(emsdkPath)[0])
+
+    # The node directory holds one versioned folder whose name changes with the SDK,
+    # so it has to be discovered rather than written down. This used to list the emsdk
+    # *root* and join the result onto emsdk/node, producing paths like
+    # <emsdk>/node/.circleci -- and since os.listdir has no defined order, a different
+    # wrong path each time. Only harmless because building a static archive never
+    # invokes the emulator; bumping the SDK is exactly when that stops being true.
+    nodeRoot = os.path.join(emsdkPath, "node")
+    nodeDirs = sorted(d for d in os.listdir(nodeRoot)
+                      if os.path.isdir(os.path.join(nodeRoot, d)))
+    if not nodeDirs:
+        raise RuntimeError(f"no node installation found under {nodeRoot}")
+    nodeExe = "node.exe" if inWindows() else "node"
+    emsdkNodePath = os.path.join(nodeRoot, nodeDirs[-1], "bin", nodeExe)
     useNinja = not inWindows() or shutil.which("ninja.exe") != None
     buildPath = build_path(target)
 


### PR DESCRIPTION
Phase 0 of bringing ImGui.Net into the toolbox — deliberately first and on its own, because it is independent of everything else and isolates the variable.

| Emscripten | LLVM | Who |
|---|---|---|
| 3.1.34 | 17 | what this repo built with |
| **3.1.56** | **19** | what the .NET SDK links with |
| 3.1.64 | 19 | what KTX.NET builds with |

Read from Emscripten's own `tools/shared.py`, and confirmed in the shipped binaries: `cimgui.a` declares `clang 17`, `ktx.a` declares `clang 19`.

The check that matters after this merges: the rebuilt `cimgui.a` must declare **clang 19**. That is the only proof the change took effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)