### PR TITLE
fix: build the sample in CI, and repair it after the cimgui bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,14 @@ jobs:
         dotnet build Generator/ImplotGen/ImplotGen.csproj
         dotnet build Generator/Evergine.Bindings.Imgui/Evergine.Bindings.Imgui.csproj
 
+    # The sample is the only thing here that consumes the binding the way a user does,
+    # so it is the only thing that notices a source-breaking change. The five projects
+    # above all still built after the February-to-July bump while the sample did not:
+    # ImDrawData.CmdListsCount had become FrameCount upstream. Building the binding
+    # proves it is well-formed, not that anybody can still call it.
+    - name: Build the sample
+      run: dotnet build Generator/Example/ExampleEvergine.Windows/ExampleEvergine.Windows.csproj
+
   # The definitions the four generators read are copies of files produced inside the
   # submodules, and the native library is compiled from those same submodules. If the
   # copies fall behind, the managed layer describes one revision while the binary is

--- a/Generator/Example/ExampleEvergine/Managers/ImGuiManager.cs
+++ b/Generator/Example/ExampleEvergine/Managers/ImGuiManager.cs
@@ -582,7 +582,7 @@ namespace ExampleEvergine.Managers
 
             ImDrawData* drawData = ImguiNative.igGetDrawData();
 
-            if (drawData->CmdListsCount == 0)
+            if (drawData->CmdLists.Size == 0)
             {
                 return;
             }
@@ -620,7 +620,7 @@ namespace ExampleEvergine.Managers
             var vResource = this.graphicsContext.MapMemory(this.vertexBuffers[0], MapMode.Write);
             var iResource = this.graphicsContext.MapMemory(this.indexBuffer, MapMode.Write);
 
-            for (int i = 0; i < drawData->CmdListsCount; i++)
+            for (int i = 0; i < drawData->CmdLists.Size; i++)
             {
                 ImVector<IntPtr> cmdList = new ImVector<IntPtr>(drawData->CmdLists);
                 ImDrawList* cmdListPtr = (ImDrawList*)cmdList[i];
@@ -663,7 +663,7 @@ namespace ExampleEvergine.Managers
             // Render command lists
             uint idx_offset = 0;
 
-            for (int n = 0; n < drawData->CmdListsCount; n++)
+            for (int n = 0; n < drawData->CmdLists.Size; n++)
             {
                 ImVector<IntPtr> cmdList = new ImVector<IntPtr>(drawData->CmdLists);
                 ImDrawList* cmdListPtr = (ImDrawList*)cmdList[n];


### PR DESCRIPTION
The sample did not compile against the regenerated binding. Three errors, one cause.

## What broke

`ImDrawData.CmdListsCount` is gone. Upstream imgui put `FrameCount` in that slot and moved `CmdListsCount` to the end of the struct behind `IMGUI_DISABLE_OBSOLETE_FUNCTIONS`, which cimgui defines, so it does not reach the binding at all. The fix is `CmdLists.Size`, which is what upstream's own comment tells callers to use.

The shape of that change is worth recording: same type, same offset, different meaning. A frame counter where a draw-list count used to be. Because the name changed, it failed loudly at compile time. Had the field merely moved, it would have compiled and used a frame number as a loop bound.

## Why CI missed it

CI built the four generators and the binding. All five still build through a source-breaking change, because none of them call the API. The sample is the only project here that consumes the binding the way a user does. It is now in CI.

## Full delta against the published 2026.4.4.26

Measured with the toolbox surface dumper, published package versus this build: **310 additions, 83 removals**. The removals break down as:

| | count | |
|---|---|---|
| Renumbered constants | **68** | same name, different value |
| Methods removed | 13 | mostly overloads that gained a parameter |
| Fields removed | 1 | `ImDrawData.CmdListsCount` |
| Constants genuinely gone | 1 | `ImGuiMultiSelectFlags.SelectOnClick` |

The 68 renumberings are the ones that matter, concentrated in `ImGuiCol` (44), `ImPlotProp` (11) and `ImGuiStyleVar` (7) — `ImGuiCol.Button` moves 21 to 22, and so does almost everything after it, because upstream inserted a colour. `ImDrawFlags.Closed` goes 1 to 512.

Enum values are inlined at compile time, so this is the silent kind of break: anything compiled against the old package and not rebuilt passes the old number to the new native library and gets a different colour, with no error anywhere. Consumers who upgrade and rebuild are fine. A prebuilt third-party assembly is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)