### PR TITLE
feat(cd): a publish-only dispatch, for shipping main when upstream has run ahead

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: boolean
         default: false
+      publish-only:
+        description: 'Publish main exactly as it stands, without looking at upstream'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   # Reads binding.yml and reports how far each of the four submodules is behind.
@@ -42,7 +47,10 @@ jobs:
 
   natives:
     needs: resolve
-    if: needs.resolve.outputs.ref_moved == 'true' || inputs.force-natives
+    # publish-only ships what is already committed, and these libraries are committed,
+    # so rebuilding them would replace binaries somebody has run with binaries nobody
+    # has. That is the opposite of the point.
+    if: (needs.resolve.outputs.ref_moved == 'true' || inputs.force-natives) && !inputs.publish-only
     uses: ./.github/workflows/build-native-libs.yml
     with:
       # The revisions the cd job is about to commit, not the ones recorded now. Without
@@ -84,6 +92,7 @@ jobs:
       # fails the download and takes the publish with it.
       natives-artifact-pattern: ${{ needs.natives.result == 'success' && 'cimgui-*' || '' }}
       force-publish: ${{ inputs.force-publish || false }}
+      publish-only: ${{ inputs.publish-only || false }}
       publish-enabled: ${{ !inputs.skip-assets-publishing }}
       enable-email-notifications: true
     secrets:


### PR DESCRIPTION
Uses `publish-only` from toolbox v1.17.0.

## Why

`force-publish=true` could not publish the reviewed revision. It fetches upstream first, and `cimgui` plus `cimplot` had moved again since the bump landed — so it bumped to the newer sources and the native build failed on upstream's own bug:

```
cimgui.cpp:6638: error: 'fmd' was not declared in this scope; did you mean 'fmt'?
```

That is a generated `CIMGUI_VARGS0` companion — `ImGuiTextBuffer_appendf(self,fmd)`, wrong identifier and no semicolon. It reaches us because this repo defines `CIMGUI_VARGS0`, and it is the same generator path reported in cimgui/cimgui#323.

The pipeline refusing was correct. It just had no way to say yes to the state that had been reviewed and run.

## What changes

A `publish-only` dispatch input. It skips the native rebuild — those libraries are versioned and are the ones that were actually exercised, so rebuilding would swap tested binaries for untested ones — and asks the toolbox to package the tree as committed.

The toolbox side refuses if regeneration changes anything, so this cannot quietly publish something `main` does not contain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)